### PR TITLE
Fix Service Aplicare Tidak Memiliki URL

### DIFF
--- a/KhanzaHMSServiceAplicare/src/khanzahmsserviceaplicare/frmUtama.java
+++ b/KhanzaHMSServiceAplicare/src/khanzahmsserviceaplicare/frmUtama.java
@@ -31,7 +31,7 @@ public class frmUtama extends javax.swing.JFrame {
     private  Connection koneksi=koneksiDB.condb();
     private final sekuel Sequel=new sekuel();
     private String requestJson;
-    private final String URL = "";
+    private final String URL = koneksiDB.URLAPIAPLICARE();
     private final String kodeppk = Sequel.cariIsi("select setting.kode_ppk from setting");
     private final BPJSApiAplicare api=new BPJSApiAplicare();
     private  HttpHeaders headers;


### PR DESCRIPTION
PR ini memperbaiki service Aplicare, dimana konfigurasi URLAPIAPLICARE tidak dipanggil, sehingga ketika service dibuild menyebabkan error URL tidak ditemukan.

![image](https://github.com/user-attachments/assets/90790cf9-3d41-4f4e-a8b3-7e60a2de3b5a)
