### PR TITLE
Fix Error `Lock Wait Timeout` Terkait Laboratorium dan Radiologi

### DIFF
--- a/src/simrskhanza/DlgPeriksaLaboratorium.java
+++ b/src/simrskhanza/DlgPeriksaLaboratorium.java
@@ -3290,13 +3290,16 @@ private void BtnHapusActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRS
                 
             if(sukses==true){
                 Sequel.Commit();
-                JOptionPane.showMessageDialog(null,"Proses simpan selesai...!");
                 isReset();
             }else{
-                JOptionPane.showMessageDialog(null,"Terjadi kesalahan saat pemrosesan data, transaksi dibatalkan.\nPeriksa kembali data sebelum melanjutkan menyimpan..!!");
                 Sequel.RollBack();
             }
             Sequel.AutoComitTrue();  
+            if(sukses==true){
+                JOptionPane.showMessageDialog(null,"Proses simpan selesai...!");
+            }else{
+                JOptionPane.showMessageDialog(null,"Terjadi kesalahan saat pemrosesan data, transaksi dibatalkan.\nPeriksa kembali data sebelum melanjutkan menyimpan..!!");
+            }
         } catch (Exception e) {
             System.out.println(e);
         }    

--- a/src/simrskhanza/DlgPeriksaLaboratoriumMB.java
+++ b/src/simrskhanza/DlgPeriksaLaboratoriumMB.java
@@ -2525,13 +2525,16 @@ private void BtnHapusActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRS
                 
             if(sukses==true){
                 Sequel.Commit();
-                JOptionPane.showMessageDialog(null,"Proses simpan selesai...!");
                 isReset();
             }else{
-                JOptionPane.showMessageDialog(null,"Terjadi kesalahan saat pemrosesan data, transaksi dibatalkan.\nPeriksa kembali data sebelum melanjutkan menyimpan..!!");
                 Sequel.RollBack();
             }
             Sequel.AutoComitTrue();  
+            if(sukses==true){
+                JOptionPane.showMessageDialog(null,"Proses simpan selesai...!");
+            }else{
+                JOptionPane.showMessageDialog(null,"Terjadi kesalahan saat pemrosesan data, transaksi dibatalkan.\nPeriksa kembali data sebelum melanjutkan menyimpan..!!");
+            }
         } catch (Exception e) {
             System.out.println(e);
         }    

--- a/src/simrskhanza/DlgPeriksaLaboratoriumPA.java
+++ b/src/simrskhanza/DlgPeriksaLaboratoriumPA.java
@@ -2116,13 +2116,16 @@ private void BtnHapusActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRS
                 
             if(sukses==true){
                 Sequel.Commit();
-                JOptionPane.showMessageDialog(null,"Proses simpan selesai...!");
                 isReset();
             }else{
-                JOptionPane.showMessageDialog(null,"Terjadi kesalahan saat pemrosesan data, transaksi dibatalkan.\nPeriksa kembali data sebelum melanjutkan menyimpan..!!");
                 Sequel.RollBack();
             }
             Sequel.AutoComitTrue();  
+            if(sukses==true){
+                JOptionPane.showMessageDialog(null,"Proses simpan selesai...!");
+            }else{
+                JOptionPane.showMessageDialog(null,"Terjadi kesalahan saat pemrosesan data, transaksi dibatalkan.\nPeriksa kembali data sebelum melanjutkan menyimpan..!!");
+            }
         } catch (Exception e) {
             System.out.println(e);
         }    

--- a/src/simrskhanza/DlgPeriksaRadiologi.java
+++ b/src/simrskhanza/DlgPeriksaRadiologi.java
@@ -2504,13 +2504,16 @@ private void ChkJlnActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:
                 
             if(sukses==true){
                 Sequel.Commit();
-                JOptionPane.showMessageDialog(null,"Proses simpan selesai...!");
                 isReset();
             }else{
-                JOptionPane.showMessageDialog(null,"Terjadi kesalahan saat pemrosesan data, transaksi dibatalkan.\nPeriksa kembali data sebelum melanjutkan menyimpan..!!");
                 Sequel.RollBack();
             }
             Sequel.AutoComitTrue();    
+            if(sukses==true){
+                JOptionPane.showMessageDialog(null,"Proses simpan selesai...!");
+            }else{
+                JOptionPane.showMessageDialog(null,"Terjadi kesalahan saat pemrosesan data, transaksi dibatalkan.\nPeriksa kembali data sebelum melanjutkan menyimpan..!!");
+            }
             ChkJln.setSelected(true);
         }
     }


### PR DESCRIPTION
PR ini mencoba memperbaiki error `Lock Wait Timeout` pada saat melakukan update terkait pemeriksaan atau permintaan laboratorium dan radiologi.

Hal ini terjadi karena pada proses menyimpan hasil laboratorium/radiologi, `JOptionPane.showMessageDialog` akan mensuspend eksekusi hingga user berinteraksi dengan pop up pemberitahuan tersebut. Apabila user tidak segera mendismiss pop up dengan klik OK atau Batal, proses commit/rollback tidak akan berjalan, dan autocommit tidak akan aktif.

Bug ini bisa direplikasi/uji coba secara lokal dengan cara menjalankan 2 Aplikasi SIMRS khanza, kemudian mengisi membuat 2 order lab, lalu mengisi hasil pemeriksaan pada salah satu orderan hingga selesai namun tidak mendismiss pop up. Order lab lainnya ketika dicoba ambil sample akan membuat aplikasi tidak merespon.