### PR TITLE
Fix nominal tidak sesuai pada saat menghapus pengeluaran harian

### DIFF
--- a/src/keuangan/DlgPengeluaranHarian.java
+++ b/src/keuangan/DlgPengeluaranHarian.java
@@ -1513,7 +1513,7 @@ private void ChkInputActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRS
             Nomor.setText(tbResep.getValueAt(tbResep.getSelectedRow(),0).toString());
             NmKategori.setText(tbResep.getValueAt(tbResep.getSelectedRow(),2).toString().replaceAll(tbResep.getValueAt(tbResep.getSelectedRow(),6).toString()+" ",""));
             NmPtg.setText(tbResep.getValueAt(tbResep.getSelectedRow(),3).toString().replaceAll(tbResep.getValueAt(tbResep.getSelectedRow(),7).toString()+" ",""));
-            Pengeluaran.setText(tbResep.getValueAt(tbResep.getSelectedRow(),4).toString());
+            Pengeluaran.setText(new java.math.BigDecimal((Double) tbResep.getValueAt(tbResep.getSelectedRow(),4)).toPlainString());
             Keterangan.setText(tbResep.getValueAt(tbResep.getSelectedRow(),5).toString());
             KdKategori.setText(tbResep.getValueAt(tbResep.getSelectedRow(),6).toString());
             KdPtg.setText(tbResep.getValueAt(tbResep.getSelectedRow(),7).toString());


### PR DESCRIPTION
PR ini mencoba memperbaiki nominal yang tidak sesuai pada saat menghapus pengeluaran harian. Hal ini terjadi karena pada saat menghapus, nilai pada kolom `Pengeluaran` tidak diconvert menjadi double terlebih dahulu, menyebabkan nominal yang dijurnal tidak sesuai.

<img width="1188" height="250" alt="image" src="https://github.com/user-attachments/assets/94feba6a-0daa-44a3-acae-c9c31ed7d006" />
